### PR TITLE
Don't parse prefix if !isServer, Disallow Empty Tags, Disallow empty Prefixes, Ensure tags object always exists!

### DIFF
--- a/src/Message/MessageParser.ts
+++ b/src/Message/MessageParser.ts
@@ -4,97 +4,107 @@ import { ServerProperties, defaultServerProperties } from '../ServerProperties';
 import { splitWithLimit } from '../Toolkit/StringTools';
 
 export default function parseMessage(
-	line: string,
-	serverProperties: ServerProperties = defaultServerProperties,
-	knownCommands: Map<string, MessageConstructor> = coreMessageTypes,
-	isServer: boolean = false,
-	nonConformingCommands: string[] = []
+  line: string,
+  serverProperties: ServerProperties = defaultServerProperties,
+  knownCommands: Map<string, MessageConstructor> = coreMessageTypes,
+  isServer: boolean = false,
+  nonConformingCommands: string[] = [],
 ): Message {
-	const splitLine: string[] = line.split(' ');
-	let token: string;
+  const splitLine: string[] = line.split(' ');
+  let token: string;
 
-	let command: string | undefined;
-	const params: MessageParam[] = [];
-	let tags: Map<string, string> | undefined;
-	let prefix: MessagePrefix | undefined;
+  let command: string | undefined;
+  const params: MessageParam[] = [];
+  let tags: Map<string, string> = new Map();
+  let prefix: MessagePrefix | undefined;
 
-	while (splitLine.length) {
-		token = splitLine[0];
-		if (token[0] === '@' && !tags && !command) {
-			tags = parseTags(token.substr(1));
-		} else if (token[0] === ':') {
-			if (!prefix && !command) {
-				if (token.length > 1) { // Not an empty prefix
-					prefix = parsePrefix(token.substr(1));
-				}
-			} else {
-				params.push({
-					value: splitLine.join(' ').substr(1),
-					trailing: true
-				});
-				break;
-			}
-		} else if (!command) {
-			command = token.toUpperCase();
-		} else {
-			params.push({
-				value: token,
-				trailing: false
-			});
-		}
-		splitLine.shift();
-	}
+  while (splitLine.length) {
+    token = splitLine[0];
+    if (token[0] === '@' && !tags && !command) {
+      tags = parseTags(token.substr(1), tags);
+    } else if (token[0] === ':') {
+      if (!prefix && !command) {
+        if (token.length > 1) {
+          // Not an empty prefix
+          prefix = parsePrefix(token.substr(1));
+        }
+      } else {
+        params.push({
+          value: splitLine.join(' ').substr(1),
+          trailing: true,
+        });
+        break;
+      }
+    } else if (!command) {
+      command = token.toUpperCase();
+    } else {
+      params.push({
+        value: token,
+        trailing: false,
+      });
+    }
+    splitLine.shift();
+  }
 
-	if (!command) {
-		throw new Error(`line without command received: ${line}`);
-	}
+  if (!command) {
+    throw new Error(`line without command received: ${line}`);
+  }
 
-	let message: Message;
+  let message: Message;
 
-	let messageClass: MessageConstructor = Message;
-	if (knownCommands.has(command)) {
-		messageClass = knownCommands.get(command)!;
-	}
+  let messageClass: MessageConstructor = Message;
+  if (knownCommands.has(command)) {
+    messageClass = knownCommands.get(command)!;
+  }
 
-	// tslint:disable-next-line:no-inferred-empty-object-type
-	message = new messageClass(command, params, tags, prefix, serverProperties, line, isServer, !nonConformingCommands.includes(command));
+  // tslint:disable-next-line:no-inferred-empty-object-type
+  message = new messageClass(
+    command,
+    params,
+    tags,
+    prefix,
+    serverProperties,
+    line,
+    isServer,
+    !nonConformingCommands.includes(command),
+  );
 
-	return message;
+  return message;
 }
 
 export function parsePrefix(raw: string): MessagePrefix {
-	const [nick, hostName] = splitWithLimit(raw, '!', 2);
-	if (hostName) {
-		const [user, host] = splitWithLimit(hostName, '@', 2);
-		if (host) {
-			return { nick, user, host };
-		} else {
-			return { nick, host: user };
-		}
-	} else {
-		return { nick };
-	}
+  const [nick, hostName] = splitWithLimit(raw, '!', 2);
+  if (hostName) {
+    const [user, host] = splitWithLimit(hostName, '@', 2);
+    if (host) {
+      return { nick, user, host };
+    } else {
+      return { nick, host: user };
+    }
+  } else {
+    return { nick };
+  }
 }
 
 const tagUnescapeMap: { [char: string]: string } = {
-	'\\': '\\',
-	':': ';',
-	n: '\n',
-	r: '\r',
-	s: ' '
+  '\\': '\\',
+  ':': ';',
+  n: '\n',
+  r: '\r',
+  s: ' ',
 };
 
-export function parseTags(raw: string): Map<string, string> | undefined {
-	const tags: Map<string, string> = new Map();
-	const tagStrings = raw.split(';');
-	for (const tagString of tagStrings) {
-		const [tagName, tagValue] = splitWithLimit(tagString, '=', 2);
-		if (tagName === '') {
-			continue; // Ignore empty tags: @ @; @x; etc.
-		}
-		// unescape according to http://ircv3.net/specs/core/message-tags-3.2.html#escaping-values
-		tags.set(tagName, tagValue.replace(/\\([\\:nrs])/g, (_, match) => tagUnescapeMap[match]));
-	}
+export function parseTags(raw: string, map?: Map<string, string>): Map<string, string> {
+  const tags: Map<string, string> = map || new Map();
+  const tagStrings = raw.split(';');
+  for (const tagString of tagStrings) {
+    const [tagName, tagValue] = splitWithLimit(tagString, '=', 2);
+    if (tagName === '') {
+      continue; // Ignore empty tags: @ @; @x; etc.
+    }
+    // unescape according to http://ircv3.net/specs/core/message-tags-3.2.html#escaping-values
+    tags.set(tagName, tagValue.replace(/\\([\\:nrs])/g, (_, match) => tagUnescapeMap[match]));
+  }
 
-	return tags.size > 0 ? tags : undefined;
+  return tags;
 }

--- a/src/Message/MessageParser.ts
+++ b/src/Message/MessageParser.ts
@@ -4,107 +4,97 @@ import { ServerProperties, defaultServerProperties } from '../ServerProperties';
 import { splitWithLimit } from '../Toolkit/StringTools';
 
 export default function parseMessage(
-  line: string,
-  serverProperties: ServerProperties = defaultServerProperties,
-  knownCommands: Map<string, MessageConstructor> = coreMessageTypes,
-  isServer: boolean = false,
-  nonConformingCommands: string[] = [],
+	line: string,
+	serverProperties: ServerProperties = defaultServerProperties,
+	knownCommands: Map<string, MessageConstructor> = coreMessageTypes,
+	isServer: boolean = false,
+	nonConformingCommands: string[] = []
 ): Message {
-  const splitLine: string[] = line.split(' ');
-  let token: string;
+	const splitLine: string[] = line.split(' ');
+	let token: string;
 
-  let command: string | undefined;
-  const params: MessageParam[] = [];
-  let tags: Map<string, string> = new Map();
-  let prefix: MessagePrefix | undefined;
+	let command: string | undefined;
+	const params: MessageParam[] = [];
+	let tags: Map<string, string> | undefined;
+	let prefix: MessagePrefix | undefined;
 
-  while (splitLine.length) {
-    token = splitLine[0];
-    if (token[0] === '@' && !tags && !command) {
-      tags = parseTags(token.substr(1), tags);
-    } else if (token[0] === ':') {
-      if (!prefix && !command) {
-        if (token.length > 1) {
-          // Not an empty prefix
-          prefix = parsePrefix(token.substr(1));
-        }
-      } else {
-        params.push({
-          value: splitLine.join(' ').substr(1),
-          trailing: true,
-        });
-        break;
-      }
-    } else if (!command) {
-      command = token.toUpperCase();
-    } else {
-      params.push({
-        value: token,
-        trailing: false,
-      });
-    }
-    splitLine.shift();
-  }
+	while (splitLine.length) {
+		token = splitLine[0];
+		if (token[0] === '@' && !tags && !command) {
+			tags = parseTags(token.substr(1));
+		} else if (token[0] === ':') {
+			if (!prefix && !command) {
+				if (token.length > 1) { // Not an empty prefix
+					prefix = parsePrefix(token.substr(1));
+				}
+			} else {
+				params.push({
+					value: splitLine.join(' ').substr(1),
+					trailing: true
+				});
+				break;
+			}
+		} else if (!command) {
+			command = token.toUpperCase();
+		} else {
+			params.push({
+				value: token,
+				trailing: false
+			});
+		}
+		splitLine.shift();
+	}
 
-  if (!command) {
-    throw new Error(`line without command received: ${line}`);
-  }
+	if (!command) {
+		throw new Error(`line without command received: ${line}`);
+	}
 
-  let message: Message;
+	let message: Message;
 
-  let messageClass: MessageConstructor = Message;
-  if (knownCommands.has(command)) {
-    messageClass = knownCommands.get(command)!;
-  }
+	let messageClass: MessageConstructor = Message;
+	if (knownCommands.has(command)) {
+		messageClass = knownCommands.get(command)!;
+	}
 
-  // tslint:disable-next-line:no-inferred-empty-object-type
-  message = new messageClass(
-    command,
-    params,
-    tags,
-    prefix,
-    serverProperties,
-    line,
-    isServer,
-    !nonConformingCommands.includes(command),
-  );
+	// tslint:disable-next-line:no-inferred-empty-object-type
+	message = new messageClass(command, params, tags, prefix, serverProperties, line, isServer, !nonConformingCommands.includes(command));
 
-  return message;
+	return message;
 }
 
 export function parsePrefix(raw: string): MessagePrefix {
-  const [nick, hostName] = splitWithLimit(raw, '!', 2);
-  if (hostName) {
-    const [user, host] = splitWithLimit(hostName, '@', 2);
-    if (host) {
-      return { nick, user, host };
-    } else {
-      return { nick, host: user };
-    }
-  } else {
-    return { nick };
-  }
+	const [nick, hostName] = splitWithLimit(raw, '!', 2);
+	if (hostName) {
+		const [user, host] = splitWithLimit(hostName, '@', 2);
+		if (host) {
+			return { nick, user, host };
+		} else {
+			return { nick, host: user };
+		}
+	} else {
+		return { nick };
+	}
 }
 
 const tagUnescapeMap: { [char: string]: string } = {
-  '\\': '\\',
-  ':': ';',
-  n: '\n',
-  r: '\r',
-  s: ' ',
+	'\\': '\\',
+	':': ';',
+	n: '\n',
+	r: '\r',
+	s: ' '
 };
 
-export function parseTags(raw: string, map?: Map<string, string>): Map<string, string> {
-  const tags: Map<string, string> = map || new Map();
-  const tagStrings = raw.split(';');
-  for (const tagString of tagStrings) {
-    const [tagName, tagValue] = splitWithLimit(tagString, '=', 2);
-    if (tagName === '') {
-      continue; // Ignore empty tags: @ @; @x; etc.
-    }
-    // unescape according to http://ircv3.net/specs/core/message-tags-3.2.html#escaping-values
-    tags.set(tagName, tagValue.replace(/\\([\\:nrs])/g, (_, match) => tagUnescapeMap[match]));
-  }
+export function parseTags(raw: string): Map<string, string> | undefined {
+	const tags: Map<string, string> = new Map();
+	const tagStrings = raw.split(';');
+	for (const tagString of tagStrings) {
+		const [tagName, tagValue] = splitWithLimit(tagString, '=', 2);
+		if (tagName === '') {
+			continue; // Ignore empty tags: @ @; @x; etc.
+		}
+		// unescape according to http://ircv3.net/specs/core/message-tags-3.2.html#escaping-values
+		tags.set(tagName, tagValue.replace(/\\([\\:nrs])/g, (_, match) => tagUnescapeMap[match]));
+	}
 
-  return tags;
+	return tags.size > 0 ? tags : undefined;
 }

--- a/src/Message/MessageParser.ts
+++ b/src/Message/MessageParser.ts
@@ -84,14 +84,15 @@ const tagUnescapeMap: { [char: string]: string } = {
 	s: ' '
 };
 
-export function parseTags(raw: string): Map<string, string> {
+export function parseTags(raw: string): Map<string, string> | undefined {
 	const tags: Map<string, string> = new Map();
 	const tagStrings = raw.split(';');
 	for (const tagString of tagStrings) {
 		const [tagName, tagValue] = splitWithLimit(tagString, '=', 2);
 		// unescape according to http://ircv3.net/specs/core/message-tags-3.2.html#escaping-values
+		if (tagName === '') continue; // Ignore empty tags: @ @; @x; etc.
 		tags.set(tagName, tagValue.replace(/\\([\\:nrs])/g, (_, match) => tagUnescapeMap[match]));
 	}
 
-	return tags;
+	return tags.size > 0 ? tags : undefined;
 }

--- a/src/Message/MessageParser.ts
+++ b/src/Message/MessageParser.ts
@@ -20,11 +20,13 @@ export default function parseMessage(
 
 	while (splitLine.length) {
 		token = splitLine[0];
-		if (token[0] === '@' && !tags && !command && isServer) {
+		if (token[0] === '@' && !tags && !command) {
 			tags = parseTags(token.substr(1));
 		} else if (token[0] === ':') {
 			if (!prefix && !command) {
-				prefix = parsePrefix(token.substr(1));
+				if (isServer) {
+					prefix = parsePrefix(token.substr(1));
+				}
 			} else {
 				params.push({
 					value: splitLine.join(' ').substr(1),

--- a/src/Message/MessageParser.ts
+++ b/src/Message/MessageParser.ts
@@ -24,7 +24,7 @@ export default function parseMessage(
 			tags = parseTags(token.substr(1));
 		} else if (token[0] === ':') {
 			if (!prefix && !command) {
-				if (isServer) {
+				if (isServer && token.substr(1) !== '') ( {
 					prefix = parsePrefix(token.substr(1));
 				}
 			} else {

--- a/src/Message/MessageParser.ts
+++ b/src/Message/MessageParser.ts
@@ -15,13 +15,13 @@ export default function parseMessage(
 
 	let command: string | undefined;
 	const params: MessageParam[] = [];
-	let tags: Map<string, string> | undefined;
+	let tags: Map<string, string> = new Map();
 	let prefix: MessagePrefix | undefined;
 
 	while (splitLine.length) {
 		token = splitLine[0];
 		if (token[0] === '@' && !tags && !command) {
-			tags = parseTags(token.substr(1));
+			tags = parseTags(token.substr(1), tags);
 		} else if (token[0] === ':') {
 			if (!prefix && !command) {
 				if (token.length > 1) { // Not an empty prefix
@@ -84,8 +84,8 @@ const tagUnescapeMap: { [char: string]: string } = {
 	s: ' '
 };
 
-export function parseTags(raw: string): Map<string, string> | undefined {
-	const tags: Map<string, string> = new Map();
+export function parseTags(raw: string, map?: Map<string, string>): Map<string, string> {
+	const tags: Map<string, string> = map || new Map();
 	const tagStrings = raw.split(';');
 	for (const tagString of tagStrings) {
 		const [tagName, tagValue] = splitWithLimit(tagString, '=', 2);
@@ -96,5 +96,5 @@ export function parseTags(raw: string): Map<string, string> | undefined {
 		tags.set(tagName, tagValue.replace(/\\([\\:nrs])/g, (_, match) => tagUnescapeMap[match]));
 	}
 
-	return tags.size > 0 ? tags : undefined;
+	return tags;
 }

--- a/src/Message/MessageParser.ts
+++ b/src/Message/MessageParser.ts
@@ -24,7 +24,7 @@ export default function parseMessage(
 			tags = parseTags(token.substr(1));
 		} else if (token[0] === ':') {
 			if (!prefix && !command) {
-				if (isServer && token.substr(1) !== '') ( {
+				if (token.length > 1) ( { // Not an empty prefix
 					prefix = parsePrefix(token.substr(1));
 				}
 			} else {
@@ -89,8 +89,10 @@ export function parseTags(raw: string): Map<string, string> | undefined {
 	const tagStrings = raw.split(';');
 	for (const tagString of tagStrings) {
 		const [tagName, tagValue] = splitWithLimit(tagString, '=', 2);
+		if (tagName === '') {
+			continue; // Ignore empty tags: @ @; @x; etc.
+		}
 		// unescape according to http://ircv3.net/specs/core/message-tags-3.2.html#escaping-values
-		if (tagName === '') continue; // Ignore empty tags: @ @; @x; etc.
 		tags.set(tagName, tagValue.replace(/\\([\\:nrs])/g, (_, match) => tagUnescapeMap[match]));
 	}
 

--- a/src/Message/MessageParser.ts
+++ b/src/Message/MessageParser.ts
@@ -15,13 +15,13 @@ export default function parseMessage(
 
 	let command: string | undefined;
 	const params: MessageParam[] = [];
-	let tags: Map<string, string> = new Map();
+	let tags: Map<string, string> | undefined;
 	let prefix: MessagePrefix | undefined;
 
 	while (splitLine.length) {
 		token = splitLine[0];
 		if (token[0] === '@' && !tags && !command) {
-			tags = parseTags(token.substr(1), tags);
+			tags = parseTags(token.substr(1));
 		} else if (token[0] === ':') {
 			if (!prefix && !command) {
 				if (token.length > 1) { // Not an empty prefix
@@ -36,6 +36,7 @@ export default function parseMessage(
 			}
 		} else if (!command) {
 			command = token.toUpperCase();
+			tags = tags || new Map(); // Define map if it doesn't already exist
 		} else {
 			params.push({
 				value: token,
@@ -84,8 +85,8 @@ const tagUnescapeMap: { [char: string]: string } = {
 	s: ' '
 };
 
-export function parseTags(raw: string, map?: Map<string, string>): Map<string, string> {
-	const tags: Map<string, string> = map || new Map();
+export function parseTags(raw: string): Map<string, string> {
+	const tags: Map<string, string> = new Map();
 	const tagStrings = raw.split(';');
 	for (const tagString of tagStrings) {
 		const [tagName, tagValue] = splitWithLimit(tagString, '=', 2);

--- a/src/Message/MessageParser.ts
+++ b/src/Message/MessageParser.ts
@@ -24,7 +24,7 @@ export default function parseMessage(
 			tags = parseTags(token.substr(1));
 		} else if (token[0] === ':') {
 			if (!prefix && !command) {
-				if (token.length > 1) ( { // Not an empty prefix
+				if (token.length > 1) { // Not an empty prefix
 					prefix = parsePrefix(token.substr(1));
 				}
 			} else {

--- a/src/Message/MessageParser.ts
+++ b/src/Message/MessageParser.ts
@@ -20,7 +20,7 @@ export default function parseMessage(
 
 	while (splitLine.length) {
 		token = splitLine[0];
-		if (token[0] === '@' && !tags && !command) {
+		if (token[0] === '@' && !tags && !command && isServer) {
 			tags = parseTags(token.substr(1));
 		} else if (token[0] === ':') {
 			if (!prefix && !command) {


### PR DESCRIPTION
Not hugely important, but it seems silly to parse a prefix we know will be ignored (according to IRC spec).