### PR TITLE
Always include tags when stringifying messages

### DIFF
--- a/src/Message/Message.ts
+++ b/src/Message/Message.ts
@@ -211,7 +211,7 @@ export class Message<T extends Message<T> = any> {
 		return [...this._tags.entries()].map(([key, value]) => (value ? `${key}=${escapeTag(value)}` : key)).join(';');
 	}
 
-	toString(complete: boolean = false): string {
+	toString(includePrefix: boolean = false): string {
 		const cls = this.constructor as MessageConstructor<T>;
 		const specKeys = Object.keys(cls.PARAM_SPEC!) as Array<MessageParamNames<T>>;
 		const fullCommand = [
@@ -231,15 +231,13 @@ export class Message<T extends Message<T> = any> {
 				.filter((param: string | undefined) => param !== undefined)
 		].join(' ');
 
-		if (!complete) {
-			return fullCommand;
-		}
-
 		const parts = [fullCommand];
 
-		const prefix = this.prefixToString();
-		if (prefix) {
-			parts.unshift(`:${prefix}`);
+		if (includePrefix) {
+			const prefix = this.prefixToString();
+			if (prefix) {
+				parts.unshift(`:${prefix}`);
+			}
 		}
 
 		const tags = this.tagsToString();

--- a/src/Message/__tests__/Message.ts
+++ b/src/Message/__tests__/Message.ts
@@ -1,0 +1,27 @@
+import { createMessage } from '../Message';
+import { PrivateMessage } from '../MessageTypes/Commands';
+
+describe('Message', () => {
+	it('should correctly stringify a PrivateMessage with tags', () => {
+		const message = createMessage(
+			PrivateMessage,
+			{ target: '#channel', content: 'A message with tags' },
+			undefined,
+			new Map([['my-tag', 'value']])
+		);
+
+		expect(message.toString()).toEqual('@my-tag=value PRIVMSG #channel :A message with tags');
+	});
+
+	it('should not include a PrivateMessage prefix by default', () => {
+		const message = createMessage(
+			PrivateMessage,
+			{ target: '#channel', content: 'A message with a prefix' },
+			{
+				nick: 'nick'
+			}
+		);
+
+		expect(message.toString()).toEqual('PRIVMSG #channel :A message with a prefix');
+	});
+});


### PR DESCRIPTION
Fixes #13

This pull request updates Message.toString so that the tags are always included. It also renames the `complete` parameter to `includePrefix`, as that's the only thing controlled by the parameter now.

I've also added two short tests to verify this behaviour. I'm not sure what general style you prefer for those, there is very little test coverage in general.
